### PR TITLE
Migrate oracle integration from Ref Finance to Rhea Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A non-leveraged, cash-settled forward product for meme coins on NEAR Protocol. T
 3. **LongToken** - NEP-141 token representing long positions
 4. **ShortToken** - NEP-141 token representing short positions
 5. **FeeCollector** - Collects and manages protocol fees
-6. **OracleRouter** - Integrates with Ref Finance for price feeds
+6. **OracleRouter** - Integrates with Rhea Finance (formerly Ref Finance) for TWAP price feeds
 
 ### Key Features
 
@@ -151,6 +151,32 @@ await marketClient.createPosition('1000000000000000000000000');
 const [longValue, shortValue] = await marketClient.previewSettlement('45000000000000000000000000');
 ```
 
+## Oracle Integration
+
+The protocol uses Rhea Finance (the merged platform of Ref Finance and Burrow) for price feeds:
+
+- **TWAP Support**: Time-weighted average prices to prevent manipulation
+- **Stable Pool Pricing**: Option to use Rhea's stable pool for stablecoin pairs
+- **Configurable Windows**: Adjustable TWAP windows (default 5 minutes)
+- **Price Caching**: Cached prices with configurable staleness limits
+- **Testnet Support**: Automatic network detection for mainnet/testnet
+
+### Configuring Oracle
+
+```bash
+near call oracle.testnet configure_oracle '{
+  "underlying": "wrap.near",
+  "quote": "usdc.near",
+  "config": {
+    "rhea_pool_id": 1234,
+    "twap_window": 300,
+    "max_staleness": 600,
+    "max_deviation_bps": 500,
+    "use_stable_pool": false
+  }
+}' --accountId owner.testnet
+```
+
 ## Security Considerations
 
 - All contracts use NEAR SDK's built-in reentrancy guards
@@ -158,7 +184,8 @@ const [longValue, shortValue] = await marketClient.previewSettlement('4500000000
 - Guardian role for operational security
 - Owner role for parameter updates
 - Strict validation of market parameters
-- No external dependencies beyond NEAR SDK and Ref Finance
+- TWAP oracles for manipulation resistance
+- No external dependencies beyond NEAR SDK and Rhea Finance
 
 ## License
 

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,13 @@ set -e
 
 echo "Building NEAR smart contracts..."
 
+# Check if testnet build is requested
+FEATURES=""
+if [ "$1" = "testnet" ]; then
+    echo "Building for TESTNET with Rhea testnet configuration..."
+    FEATURES="--features testnet"
+fi
+
 CONTRACTS=(
     "long-token"
     "short-token"
@@ -15,7 +22,14 @@ CONTRACTS=(
 for contract in "${CONTRACTS[@]}"; do
     echo "Building $contract..."
     cd contracts/$contract
-    cargo build --target wasm32-unknown-unknown --release
+    
+    # Add features flag for oracle-router
+    if [ "$contract" = "oracle-router" ] && [ -n "$FEATURES" ]; then
+        cargo build --target wasm32-unknown-unknown --release $FEATURES
+    else
+        cargo build --target wasm32-unknown-unknown --release
+    fi
+    
     cd ../..
 done
 

--- a/client/near-client.ts
+++ b/client/near-client.ts
@@ -269,7 +269,7 @@ export class NEP141TokenClient {
   }
 }
 
-// Oracle Router Client
+// Oracle Router Client (Updated for Rhea Finance)
 export class OracleRouterClient {
   private connection: any;
   private wallet: WalletConnection;
@@ -295,6 +295,7 @@ export class OracleRouterClient {
         changeMethods: [
           'configure_oracle',
           'fetch_price',
+          'fetch_and_cache_price',
           'set_paused',
         ],
       }
@@ -309,6 +310,36 @@ export class OracleRouterClient {
     await this.contract.fetch_price({
       args: { underlying, quote },
       gas: new BN('50000000000000'),
+    });
+  }
+
+  async fetchAndCachePrice(underlying: string, quote: string): Promise<void> {
+    await this.contract.fetch_and_cache_price({
+      args: { underlying, quote },
+      gas: new BN('50000000000000'),
+    });
+  }
+
+  async configureOracle(
+    underlying: string,
+    quote: string,
+    poolId: number,
+    twapWindow: number = 300, // 5 minutes default
+    useStablePool: boolean = false
+  ): Promise<void> {
+    await this.contract.configure_oracle({
+      args: {
+        underlying,
+        quote,
+        config: {
+          rhea_pool_id: poolId,
+          twap_window: twapWindow,
+          max_staleness: 600, // 10 minutes
+          max_deviation_bps: 500, // 5%
+          use_stable_pool: useStablePool,
+        },
+      },
+      gas: new BN('30000000000000'),
     });
   }
 }

--- a/contracts/oracle-router/Cargo.toml
+++ b/contracts/oracle-router/Cargo.toml
@@ -12,6 +12,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uint = { workspace = true }
 
+[features]
+default = []
+testnet = []
+
 [profile.release]
 codegen-units = 1
 opt-level = "z"


### PR DESCRIPTION
## Summary

This PR migrates the oracle integration from Ref Finance to Rhea Finance, following the merger of Ref Finance and Burrow into a unified DeFi platform on NEAR Protocol.

## Changes

### Oracle Router Contract
- Updated contract addresses from `v2.ref-finance.near` to `rhea.near` (mainnet) and `rhea.testnet` (testnet)
- Renamed `ref_pool_id` to `rhea_pool_id` in OracleConfig struct
- Added support for Rhea's stable pool pricing method via `use_stable_pool` flag
- Implemented `fetch_and_cache_price` method for improved price management
- Added testnet feature flag for network-specific deployments

### TypeScript Client
- Added `fetchAndCachePrice` method to OracleRouterClient
- Implemented `configureOracle` helper method with Rhea-specific parameters
- Updated method signatures to support new oracle configuration options

### Documentation
- Added comprehensive Oracle Integration section to README
- Included configuration examples for Rhea Finance pools
- Updated architecture description to reflect Rhea Finance integration
- Added TWAP oracle benefits to security considerations

### Build System
- Enhanced build script to support testnet builds with `./build.sh testnet`
- Added conditional compilation for oracle-router with feature flags

## Breaking Changes

- `OracleConfig.ref_pool_id` renamed to `rhea_pool_id`
- Oracle contract addresses changed to Rhea Finance endpoints
- Added required `use_stable_pool` field to OracleConfig

## Testing

- [ ] Unit tests pass with new Rhea interface
- [ ] Integration tests updated for Rhea Finance pools
- [ ] Testnet deployment verified with rhea.testnet
- [ ] TWAP price fetching confirmed working
- [ ] Stable pool pricing tested for stablecoin pairs

## Migration Guide

Projects using the previous Ref Finance integration should:

1. Update oracle configuration to use `rhea_pool_id` instead of `ref_pool_id`
2. Add `use_stable_pool: false` to existing configurations
3. Redeploy oracle-router contract with updated addresses
4. Update client code to use new TypeScript methods if needed

## Related Issues

Addresses the need to maintain oracle functionality after Ref Finance merger with Burrow.